### PR TITLE
Fix GH action to deploy website

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,6 +18,6 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-gems-
 
-      - uses: helaili/jekyll-action@2.0.4
-        env:
-          JEKYLL_PAT: ${{ secrets.PUSH_GITHUB_SECRET }}
+      - uses: helaili/jekyll-action@2.2.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Updates to the latest for jekyll-action; see usage instructions here: https://github.com/helaili/jekyll-action

Though it seems the website did get updated even though the action failed for the production branch. It's also unclear to me which branch it deployed from :|