### PR TITLE
docs(get-started): quote URL for kubectl apply

### DIFF
--- a/get-started/index.md
+++ b/get-started/index.md
@@ -21,7 +21,7 @@ Once installed, proceed with one of the Cryostat Operator installation options b
 ### Install with kubectl
 ```
 $ kubectl create namespace cryostat-operator-system
-$ kubectl apply -k github.com/cryostatio/cryostat-operator//config/default?ref=v1.0.0
+$ kubectl apply -k 'github.com/cryostatio/cryostat-operator//config/default?ref=v1.0.0'
 ```
 
 ### Install with operator bundle


### PR DESCRIPTION
Adds single-quotes around Kustomize URL in `kubectl apply` command. Needed to work on zsh.

Relates to #30 