### PR TITLE
feat(analytics): add Red Hat analytics

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -1,4 +1,5 @@
 <head>
+  {%- include rh-analytics-head.html -%}
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/_includes/rh-analytics-footer.html
+++ b/_includes/rh-analytics-footer.html
@@ -1,0 +1,5 @@
+<script type="text/javascript">
+    if (("undefined" !== typeof _satellite) && ("function" === typeof _satellite.pageBottom)) {
+        _satellite.pageBottom();
+    }
+</script>

--- a/_includes/rh-analytics-head.html
+++ b/_includes/rh-analytics-head.html
@@ -1,0 +1,6 @@
+{% if jekyll.environment == "development" %}
+  <script id="dpal" src="https://www.redhat.com/ma/dpal-staging.js" type="text/javascript"></script>
+{% endif %}
+{% if jekyll.environment == "production" %}
+  <script id="dpal" src="https://www.redhat.com/ma/dpal.js" type="text/javascript"></script>
+{% endif %}

--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -1,0 +1,3 @@
+<script src="https://code.jquery.com/jquery-3.3.1.min.js"></script>
+<script src="{{ '/assets/javascript/guides-version-dropdown.js' | relative_url }}" type="text/javascript"></script>
+<script src="{{ '/assets/javascript/back-to-top.js' | relative_url }}" type="text/javascript"></script>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -15,9 +15,7 @@
 
     {%- include footer.html -%}
     {%- include redhat-footer.html -%}
-    <script src="https://code.jquery.com/jquery-3.3.1.min.js"></script>
-    <script src="{{ '/assets/javascript/guides-version-dropdown.js' | relative_url }}" type="text/javascript"></script>
-    <script src="{{ '/assets/javascript/back-to-top.js' | relative_url }}" type="text/javascript"></script>
+    {%- include scripts.html -%}
   </body>
 
 </html>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -16,6 +16,7 @@
     {%- include footer.html -%}
     {%- include redhat-footer.html -%}
     {%- include scripts.html -%}
+    {%- include rh-analytics-footer.html -%}
   </body>
 
 </html>

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -29,9 +29,7 @@
     {%- include footer.html -%}
     {%- include redhat-footer.html -%}
     {%- include scripts.html -%}
+    {%- include rh-analytics-footer.html -%}
   </body>
 
 </html>
-
-
-

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -28,9 +28,7 @@
 
     {%- include footer.html -%}
     {%- include redhat-footer.html -%}
-    <script src="https://code.jquery.com/jquery-3.3.1.min.js"></script>
-    <script src="{{ '/assets/javascript/guides-version-dropdown.js' | relative_url }}" type="text/javascript"></script>
-    <script src="{{ '/assets/javascript/back-to-top.js' | relative_url }}" type="text/javascript"></script>
+    {%- include scripts.html -%}
   </body>
 
 </html>


### PR DESCRIPTION
- chore(includes): extract scripts file
- feat(analytics): add Red Hat analytics

This adds analytics pointing at the "staging" script if the Jekyll env is "development", which it is when doing a local "bundle exec jekyll serve". When built by GitHub Pages the env is supposedly set to "production" (this makes sense and I've seen it stated on StackOverflow etc., but haven't seen it documented by GitHub), so it points to the "published" analytics script.
