### PR TITLE
fix(deps): add missing webrick dependency for ruby >= 3.0.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,3 +27,6 @@ end
 
 # Performance-booster for watching directories on Windows
 gem "wdm", "~> 0.1.1", :platforms => [:mingw, :x64_mingw, :mswin]
+
+# Add webrick dependency for Ruby >= 3.0.0
+gem "webrick", "~> 1.7"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -64,6 +64,7 @@ GEM
     terminal-table (2.0.0)
       unicode-display_width (~> 1.1, >= 1.1.1)
     unicode-display_width (1.8.0)
+    webrick (1.7.0)
 
 PLATFORMS
   ruby
@@ -76,6 +77,7 @@ DEPENDENCIES
   tzinfo (~> 1.2)
   tzinfo-data
   wdm (~> 0.1.1)
+  webrick (~> 1.7)
 
 BUNDLED WITH
-   2.2.16
+   2.3.15


### PR DESCRIPTION
Fixes #52 

Add `webrick` as dependency for Ruby >= 3.0.0