### PR TITLE
chore(gem): update bundler and dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ source "https://rubygems.org"
 #
 # This will help ensure the proper Jekyll version is running.
 # Happy Jekylling!
-gem "jekyll", "~> 4.3.0"
+gem "jekyll", "~> 4.3.2"
 # This is the default theme for new Jekyll sites. You may change this to anything you like.
 gem "minima", "~> 2.5"
 # If you want to use GitHub Pages, remove the "gem "jekyll"" above and

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    addressable (2.8.4)
+    addressable (2.8.5)
       public_suffix (>= 2.0.2, < 6.0)
     colorator (1.1.0)
     concurrent-ruby (1.2.2)
@@ -11,10 +11,10 @@ GEM
     eventmachine (1.2.7)
     ffi (1.15.5)
     forwardable-extended (2.6.0)
-    google-protobuf (3.23.1)
-    google-protobuf (3.23.1-x86_64-linux)
+    google-protobuf (3.24.3)
+    google-protobuf (3.24.3-x86_64-linux)
     http_parser.rb (0.8.0)
-    i18n (1.13.0)
+    i18n (1.14.1)
       concurrent-ruby (~> 1.0)
     jekyll (4.3.2)
       addressable (~> 2.4)
@@ -37,7 +37,7 @@ GEM
     jekyll-paginate (1.1.0)
     jekyll-sass-converter (3.0.0)
       sass-embedded (~> 1.54)
-    jekyll-seo-tag (2.7.1)
+    jekyll-seo-tag (2.8.0)
       jekyll (>= 3.8, < 5.0)
     jekyll-watch (2.2.1)
       listen (~> 3.0)
@@ -56,19 +56,19 @@ GEM
       jekyll-seo-tag (~> 2.1)
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
-    public_suffix (5.0.1)
+    public_suffix (5.0.3)
     rake (13.0.6)
     rb-fsevent (0.11.2)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
-    rexml (3.2.5)
-    rouge (4.1.1)
+    rexml (3.2.6)
+    rouge (4.1.3)
     safe_yaml (1.0.5)
-    sass-embedded (1.62.1)
-      google-protobuf (~> 3.21)
-      rake (>= 10.0.0)
-    sass-embedded (1.62.1-x86_64-linux-gnu)
-      google-protobuf (~> 3.21)
+    sass-embedded (1.67.0)
+      google-protobuf (~> 3.23)
+      rake (>= 13.0.0)
+    sass-embedded (1.67.0-x86_64-linux-gnu)
+      google-protobuf (~> 3.23)
     terminal-table (3.0.2)
       unicode-display_width (>= 1.1.1, < 3)
     unicode-display_width (2.4.2)
@@ -79,7 +79,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  jekyll (~> 4.3.0)
+  jekyll (~> 4.3.2)
   jekyll-feed (~> 0.17)
   jekyll-paginate
   minima (~> 2.5)
@@ -89,4 +89,4 @@ DEPENDENCIES
   webrick (~> 1.8)
 
 BUNDLED WITH
-   2.3.15
+   2.4.10

--- a/_config.yml
+++ b/_config.yml
@@ -38,6 +38,7 @@ plugins:
 
 sass:
   style: compressed
+  quiet_deps: true
 
 collections:
   guides:


### PR DESCRIPTION
Closes #131 

Update bundler version to `2.4.10` (Fedora 38) and other deps.

As for the sass warnings, it is `jekyll-sass-converter (3.0.0)` (i.e. new sass regulations) and `minima` incompatibility that caused the issue. 
- `minima` addressed it in latest commits on main. However, no patch release came out for pretty much 3 years now:  https://github.com/jekyll/minima/issues/709
- Workaround by just muting the warnings since we can't really do anything about it: https://sass-lang.com/documentation/js-api/interfaces/options/#quietDeps