### PR TITLE
docs(operator): Add operator configuration guide

### DIFF
--- a/config/_subsections/configuring-the-operator.md
+++ b/config/_subsections/configuring-the-operator.md
@@ -34,7 +34,7 @@ spec:
 ```
 
 ### Custom Event Templates
-All **JDK Flight Recordings** created by **Cryostat** are configured using an event template. These templates specify which events to record, and **Cryostat** includes some templates automatically, including those provided by the target's JVM. **Cryostat** also provides the ability to [upload customized templates](#download-edit-and-upload-a-customized-event-template), which can then be used to create recordings.
+All **JDK Flight Recordings** created by **Cryostat** are configured using an event template. These templates specify which events to record, and **Cryostat** includes some templates automatically, including those provided by the target's JVM. **Cryostat** also provides the ability to [upload customized templates](/guides/#download-edit-and-upload-a-customized-event-template), which can then be used to create recordings.
 
 The **Cryostat Operator** provides an additional feature to pre-configure **Cryostat** with custom templates that are stored in **Config Maps**. When **Cryostat** is deployed from this **Cryostat** object, it will have the listed templates already available for use.
 ```yaml

--- a/config/index.md
+++ b/config/index.md
@@ -5,3 +5,5 @@ title: Cryostat Advanced Configuration
 
 * auto-gen TOC:
 {:toc}
+
+{% include_relative _subsections/configuring-the-operator.md %}

--- a/guides/index.md
+++ b/guides/index.md
@@ -69,7 +69,5 @@ common actions and workflows of interest and why they are useful.
 
 {% include_relative _subsections/external-storage.md %}
 
-{% include_relative _subsections/configuring-the-operator.md %}
-
 [comment]: # ## [Analyze Recordings Online](#analyze-recordings-online)
 [comment]: # TODO


### PR DESCRIPTION
Fixes https://github.com/cryostatio/cryostatio.github.io/issues/224

Adds the operator configuration guide from the cryostat-operator repo to the upstream website. Content is  the same other than the introductory paragraph and some formatting changes throughout.