### PR TITLE
docs(guides): document ConfigMap-backed trusted certificates

### DIFF
--- a/guides/_subsections/add-a-trusted-certificate.md
+++ b/guides/_subsections/add-a-trusted-certificate.md
@@ -26,11 +26,13 @@ certificate(s) within the truststore directory.
 
 ### [Preconfiguring Trusted Certificates within Cryostat](#preconfiguring-trusted-certificates-within-cryostat)
 
-Alternatively if deploying **Cryostat** in a **Kubernetes** environment with the **Cryostat Operator**, TLS Certs can be preconfigured in **Cryostat** when creating the custom resource. To begin, create a **Kubernetes** Secret containing the TLS Cert.
+Alternatively if deploying **Cryostat** in a **Kubernetes** environment with the **Cryostat Operator**, TLS certificates can be preconfigured in **Cryostat** when creating the custom resource. To begin, create a **Kubernetes** Secret or **ConfigMap** containing the TLS certificate or CA bundle.
 
 ```kubectl create secret generic application-cert --from-file=tlsCert.crt```
 
-Now that this Secret has been created, when creating the **Cryostat Custom Resource** we can specify it, either through the **Red Hat Openshift** console under **Trusted TLS Certificates** while creating the **Cryostat Custom Resource**, or through the **Custom Resource** YAML:
+```kubectl create configmap application-ca --from-file=service-ca.crt```
+
+Now that this Secret or ConfigMap has been created, when creating the **Cryostat Custom Resource** we can specify it, either through the **Red Hat OpenShift** console under **Trusted TLS Certificates** while creating the **Cryostat Custom Resource**, or through the **Custom Resource** YAML:
 
 ```yaml
 apiVersion: operator.cryostat.io/v1beta2
@@ -41,6 +43,10 @@ spec:
   trustedCertSecrets:
     - secretName: application-cert
       certificateKey: tlsCert.crt
+    - configMapName: application-ca
+      certificateKey: service-ca.crt
 ```
 
-Once the **Custom Resource** has been created, the TLS Certificate will be pre-loaded into **Cryostat** and be available from startup without any further configuration needed.
+Each `trustedCertSecrets` entry must specify exactly one of `secretName` or `configMapName`. If `certificateKey` is omitted, the default key name is `tls.crt` for Secrets and `service-ca.crt` for ConfigMaps. The ConfigMap default is useful for OpenShift service CA bundles.
+
+Once the **Custom Resource** has been created, the TLS certificate will be pre-loaded into **Cryostat** and be available from startup without any further configuration needed.


### PR DESCRIPTION
Updates the trusted certificate guide to show how Cryostat Operator users can preconfigure trusted certificates from either Secrets or ConfigMaps.